### PR TITLE
Change helm source to https://charts.containeroo.ch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation ([#1])
 
+### Changed
+
+- Change helm source to https://charts.containeroo.ch ([#4])
+
 [Unreleased]: https://github.com/projectsyn/component-nfs-client-provisioner/compare/1dee7be0a89165228756f70a106e8d8f62cbf5eb...HEAD
 [#1]: https://github.com/projectsyn/component-nfs-client-provisioner/pull/1
+[#4]: https://github.com/projectsyn/component-nfs-client-provisioner/pull/4

--- a/class/nfs-client-provisioner.yml
+++ b/class/nfs-client-provisioner.yml
@@ -2,7 +2,7 @@ parameters:
   kapitan:
     dependencies:
       - type: helm
-        source: https://kubernetes-charts.storage.googleapis.com
+        source: https://charts.containeroo.ch
         version: ${nfs_client_provisioner:charts:nfs_client_provisioner}
         chart_name: nfs-client-provisioner
         output_path: dependencies/nfs-client-provisioner/helmcharts/nfs-client-provisioner


### PR DESCRIPTION
https://kubernetes-charts.storage.googleapis.com is no
longer available.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.

