### PR TITLE
Remove helm namespace postprocess filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change helm source to https://charts.containeroo.ch ([#4])
+- Remove helm namespace postprocess filter ([#5])
 
 [Unreleased]: https://github.com/projectsyn/component-nfs-client-provisioner/compare/1dee7be0a89165228756f70a106e8d8f62cbf5eb...HEAD
 [#1]: https://github.com/projectsyn/component-nfs-client-provisioner/pull/1
 [#4]: https://github.com/projectsyn/component-nfs-client-provisioner/pull/4
+[#5]: https://github.com/projectsyn/component-nfs-client-provisioner/pull/5

--- a/postprocess/filters.yml
+++ b/postprocess/filters.yml
@@ -1,6 +1,0 @@
-filters:
-  - path: nfs-client-provisioner/01_helmchart/nfs-client-provisioner/templates
-    type: builtin
-    filter: helm_namespace
-    filterargs:
-      namespace: ${nfs_client_provisioner:namespace}


### PR DESCRIPTION
This is no longer required since ArgoCD
does take the namespace in the Application
object as reference.

## Checklist
- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the ./CHANGELOG.md.
